### PR TITLE
Upgrade the project to Go 1.26

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,10 +15,10 @@ jobs:
     name: Check
     runs-on: ubuntu-latest
     steps:
-      - name: Set up Go 1.23.x
+      - name: Set up Go 1.26.x
         uses: actions/setup-go@v4
         with:
-          go-version: 1.23.x
+          go-version: 1.26.x
           cache-dependency-path: go.sum
 
       - name: Checkout Code
@@ -47,10 +47,10 @@ jobs:
       - name: Checkout Code
         uses: actions/checkout@v3
 
-      - name: Set up Go 1.23.x
+      - name: Set up Go 1.26.x
         uses: actions/setup-go@v4
         with:
-          go-version: 1.23.x
+          go-version: 1.26.x
           cache-dependency-path: go.sum
 
       - name: Test Go-Query-DSL

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,8 @@
 module go.companyinfo.dev/go-query-dsl
 
-go 1.23
+go 1.26
 
-require github.com/stretchr/testify v1.10.0
+require github.com/stretchr/testify v1.11.1
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -16,6 +16,8 @@ github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0t
 github.com/rogpeppe/go-internal v1.14.1/go.mod h1:MaRKkUm5W0goXpeCfT7UZI6fk/L7L7so1lCWt35ZSgc=
 github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
+github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
+github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=


### PR DESCRIPTION
### Changes
- Updated the Go version to 1.26.
- Updated Go modules and dependencies where required.
- Verified the project builds successfully with the new Go version.