### PR TITLE
make Param range bounds generic over value type

### DIFF
--- a/query/term_level/range/range.go
+++ b/query/term_level/range/range.go
@@ -2,9 +2,16 @@
 // Returns documents that contain terms within a provided range.
 package ranging
 
+import "errors"
+
+// Value is the set of Go types a range bound (GT/GTE/LT/LTE) may hold. It covers every
+// Elasticsearch field family a range query can target: numeric (long, integer, float, double, ...),
+// term-like strings (keyword, ip, version), and dates via time.Time.
+type Value any
+
 // Range represents a range query, specifying range conditions for a field.
-type Range struct {
-	Range map[string]*Param `json:"range"`
+type Range[T Value] struct {
+	Range map[string]*Param[T] `json:"range"`
 }
 
 type relationType string
@@ -20,55 +27,55 @@ const (
 
 // Param represents the parameters for a range query, including greater than (GT), greater than or equal to (GTE),
 // less than (LT), less than or equal to (LTE), format, relation, timezone, and boost.
-type Param struct {
-	GT       string       `json:"gt,omitempty"`
-	GTE      string       `json:"gte,omitempty"`
-	LT       string       `json:"lt,omitempty"`
-	LTE      string       `json:"lte,omitempty"`
+type Param[T Value] struct {
+	GT       *T           `json:"gt,omitempty"`
+	GTE      *T           `json:"gte,omitempty"`
+	LT       *T           `json:"lt,omitempty"`
+	LTE      *T           `json:"lte,omitempty"`
 	Format   string       `json:"format,omitempty"`
 	Relation relationType `json:"relation,omitempty"`
 	Timezone string       `json:"timezone,omitempty"`
-	Boost    float64      `json:"boost,omitempty"`
+	Boost    *float64     `json:"boost,omitempty"`
 }
 
 // New creates a new Range instance with the specified field and range parameters.
-func New(f string, rp *Param) *Range {
-	return &Range{Range: map[string]*Param{f: rp}}
+func New[T Value](f string, rp *Param[T]) *Range[T] {
+	return &Range[T]{Range: map[string]*Param[T]{f: rp}}
 }
 
 // NewParam creates a new Param instance for range query parameters.
-func NewParam() *Param {
-	return &Param{}
+func NewParam[T Value]() *Param[T] {
+	return &Param[T]{}
 }
 
 // SetGT sets the greater than (GT) condition in the range query parameter.
-func (p *Param) SetGT(value string) *Param {
-	p.GT = value
+func (p *Param[T]) SetGT(value T) *Param[T] {
+	p.GT = &value
 	return p
 }
 
 // SetGTE sets the greater than or equal to (GTE) condition in the range query parameter.
-func (p *Param) SetGTE(value string) *Param {
-	p.GTE = value
+func (p *Param[T]) SetGTE(value T) *Param[T] {
+	p.GTE = &value
 	return p
 }
 
 // SetLT sets the less than (LT) condition in the range query parameter.
-func (p *Param) SetLT(value string) *Param {
-	p.LT = value
+func (p *Param[T]) SetLT(value T) *Param[T] {
+	p.LT = &value
 	return p
 }
 
 // SetLTE sets the less than or equal to (LTE) condition in the range query parameter.
-func (p *Param) SetLTE(value string) *Param {
-	p.LTE = value
+func (p *Param[T]) SetLTE(value T) *Param[T] {
+	p.LTE = &value
 	return p
 }
 
 // SetFormat sets the format condition in the range query parameter.
 // Date format used to convert date values in the query.
 // Default is the field’s mapped format.
-func (p *Param) SetFormat(value string) *Param {
+func (p *Param[T]) SetFormat(value string) *Param[T] {
 	p.Format = value
 	return p
 }
@@ -78,7 +85,7 @@ func (p *Param) SetFormat(value string) *Param {
 // - INTERSECTS (default): Matches documents whose range field value intersects the range provided in the query.
 // - CONTAINS: Matches documents whose range field value contains the entire range provided in the query.
 // - WITHIN: Matches documents whose range field value is entirely within the range provided in the query.
-func (p *Param) SetRelation(value relationType) *Param {
+func (p *Param[T]) SetRelation(value relationType) *Param[T] {
 	p.Relation = value
 	return p
 }
@@ -88,15 +95,34 @@ func (p *Param) SetRelation(value relationType) *Param {
 // Values above 1.0 increase the field’s relevance.
 // Values between 0.0 and 1.0 decrease the field’s relevance.
 // Default is 1.0.
-func (p *Param) SetBoost(value float64) *Param {
-	p.Boost = value
+func (p *Param[T]) SetBoost(value float64) *Param[T] {
+	p.Boost = &value
 	return p
 }
 
 // SetTimezone sets the timezone condition in the range query parameter.
 // The time zone used to convert date values to UTC in the query.
 // Valid values are ISO 8601 UTC offsets and IANA time zone IDs.
-func (p *Param) SetTimezone(value string) *Param {
+func (p *Param[T]) SetTimezone(value string) *Param[T] {
 	p.Timezone = value
 	return p
+}
+
+// Validate reports configuration mistakes that Elasticsearch would otherwise reject at query
+// time, so callers can catch them while still building the request. It does not (and cannot,
+// without a mapping lookup) check that the field itself accepts type T.
+func (p *Param[T]) Validate() error {
+	if p.GT != nil && p.GTE != nil {
+		return errors.New("ranging: GT and GTE are mutually exclusive")
+	}
+
+	if p.LT != nil && p.LTE != nil {
+		return errors.New("ranging: LT and LTE are mutually exclusive")
+	}
+
+	if p.GT == nil && p.GTE == nil && p.LT == nil && p.LTE == nil {
+		return errors.New("ranging: at least one of GT, GTE, LT, LTE must be set")
+	}
+
+	return nil
 }

--- a/query/term_level/range/range_test.go
+++ b/query/term_level/range/range_test.go
@@ -1,88 +1,206 @@
 package ranging
 
 import (
+	"encoding/json"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/suite"
 )
 
-type RangeTestSuite struct {
-	suite.Suite
-	ranges *Range
-	param  *Param
+// ptr returns a pointer to v. Bound fields (GT/GTE/LT/LTE/Boost) are now typed as pointers so a
+// legitimate zero value can be distinguished from "unset" — this helper just makes building the
+// expected *Param values in these tests convenient.
+func ptr[T any](v T) *T {
+	return &v
 }
 
-func (r *RangeTestSuite) SetupTest() {
-	r.ranges = &Range{Range: map[string]*Param{"date": {}}}
-	r.param = &Param{}
+// RangeTestSuite exercises the string-bound case (e.g. date strings, keyword terms), mirroring
+// the original suite. See TestNew_Numeric, TestNew_Time, TestValidate, and
+// TestZeroValueBoundIsEmitted below for coverage of the other Value types and the behavior that
+// changed when GT/GTE/LT/LTE moved from bare string to *T.
+type RangeTestSuite struct {
+	suite.Suite
 }
 
 func (r *RangeTestSuite) TestNewRange_Success() {
 	require := r.Require()
+	rang := &Range[string]{Range: map[string]*Param[string]{"date": {}}}
 
-	require.Equal(r.ranges, New("date", &Param{}))
+	require.Equal(rang, New("date", &Param[string]{}))
 }
 
 func (r *RangeTestSuite) TestNewParam_Success() {
 	require := r.Require()
+	param := &Param[string]{}
 
-	require.Equal(r.param, NewParam())
+	require.Equal(param, NewParam[string]())
 }
 
 func (r *RangeTestSuite) TestSetGT_Success() {
 	require := r.Require()
-	r.param = &Param{GT: "2022-04-17T06:00:00"}
+	param := &Param[string]{GT: ptr("2022-04-17T06:00:00")}
 
-	require.Equal(r.param, NewParam().SetGT("2022-04-17T06:00:00"))
+	require.Equal(param, NewParam[string]().SetGT("2022-04-17T06:00:00"))
 }
 
 func (r *RangeTestSuite) TestSetGTE_Success() {
 	require := r.Require()
-	r.param = &Param{GTE: "2022-04-17T06:00:00"}
+	param := &Param[string]{GTE: ptr("2022-04-17T06:00:00")}
 
-	require.Equal(r.param, NewParam().SetGTE("2022-04-17T06:00:00"))
+	require.Equal(param, NewParam[string]().SetGTE("2022-04-17T06:00:00"))
 }
 
 func (r *RangeTestSuite) TestSetLT_Success() {
 	require := r.Require()
-	r.param = &Param{LT: "2022-04-17T06:00:00"}
+	param := &Param[string]{LT: ptr("2022-04-17T06:00:00")}
 
-	require.Equal(r.param, NewParam().SetLT("2022-04-17T06:00:00"))
+	require.Equal(param, NewParam[string]().SetLT("2022-04-17T06:00:00"))
 }
 
 func (r *RangeTestSuite) TestSetLTE_Success() {
 	require := r.Require()
-	r.param = &Param{LTE: "2022-04-17T06:00:00"}
+	param := &Param[string]{LTE: ptr("2022-04-17T06:00:00")}
 
-	require.Equal(r.param, NewParam().SetLTE("2022-04-17T06:00:00"))
+	require.Equal(param, NewParam[string]().SetLTE("2022-04-17T06:00:00"))
 }
 
 func (r *RangeTestSuite) TestSetFormat_Success() {
 	require := r.Require()
-	r.param = &Param{Format: "epoch_millis"}
+	param := &Param[string]{Format: "epoch_millis"}
 
-	require.Equal(r.param, NewParam().SetFormat("epoch_millis"))
+	require.Equal(param, NewParam[string]().SetFormat("epoch_millis"))
 }
 
 func (r *RangeTestSuite) TestSetRelation_Success() {
 	require := r.Require()
-	r.param = &Param{Relation: IntersectsRelationType}
+	param := &Param[string]{Relation: IntersectsRelationType}
 
-	require.Equal(r.param, NewParam().SetRelation(IntersectsRelationType))
+	require.Equal(param, NewParam[string]().SetRelation(IntersectsRelationType))
 }
 
 func (r *RangeTestSuite) TestSetBoost_Success() {
 	require := r.Require()
-	r.param = &Param{Boost: 1.0}
+	param := &Param[string]{Boost: ptr(1.0)}
 
-	require.Equal(r.param, NewParam().SetBoost(1.0))
+	require.Equal(param, NewParam[string]().SetBoost(1.0))
 }
 
 func (r *RangeTestSuite) TestSetTimezone_Success() {
 	require := r.Require()
-	r.param = &Param{Timezone: "-04:00"}
+	param := &Param[string]{Timezone: "-04:00"}
 
-	require.Equal(r.param, NewParam().SetTimezone("-04:00"))
+	require.Equal(param, NewParam[string]().SetTimezone("-04:00"))
+}
+
+// TestNew_Numeric covers int64/float64 bounds, the main case the generic rewrite was for.
+func (r *RangeTestSuite) TestNew_Numeric() {
+	require := r.Require()
+	got := New("turnover", NewParam[int64]().SetGTE(100000).SetLTE(500000))
+	want := &Range[int64]{Range: map[string]*Param[int64]{
+		"turnover": {GTE: ptr(int64(100000)), LTE: ptr(int64(500000))},
+	}}
+
+	require.Equal(want, got)
+
+	b, err := json.Marshal(got)
+
+	require.NoError(err)
+	require.JSONEq(`{"range":{"turnover":{"gte":100000,"lte":500000}}}`, string(b))
+}
+
+func (r *RangeTestSuite) TestNew_Float() {
+	require := r.Require()
+	got := New("profit", NewParam[float64]().SetGT(0))
+	want := &Range[float64]{Range: map[string]*Param[float64]{
+		"profit": {GT: ptr(0.0)},
+	}}
+
+	require.Equal(want, got)
+
+	b, err := json.Marshal(got)
+
+	require.NoError(err)
+	require.JSONEq(`{"range":{"profit":{"gt":0}}}`, string(b))
+}
+
+// TestNew_Time covers a time.Time bound, marshaled as RFC3339 by default.
+func (r *RangeTestSuite) TestNew_Time() {
+	require := r.Require()
+	start := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	end := time.Date(2026, 2, 1, 0, 0, 0, 0, time.UTC)
+	got := New("createdAt", NewParam[time.Time]().SetGTE(start).SetLT(end))
+	b, err := json.Marshal(got)
+
+	require.NoError(err)
+	require.JSONEq(`{"range":{"createdAt":{"gte":"2026-01-01T00:00:00Z","lt":"2026-02-01T00:00:00Z"}}}`, string(b))
+}
+
+// TestZeroValueBoundIsEmitted guards against the bug the old string+omitempty fields had:
+// an explicit zero bound must still appear in the JSON body, not be dropped as "unset".
+func (r *RangeTestSuite) TestZeroValueBoundIsEmitted() {
+	require := r.Require()
+	got := New("profit", NewParam[int64]().SetGTE(0))
+	b, err := json.Marshal(got)
+
+	require.NoError(err)
+	require.JSONEq(`{"range":{"profit":{"gte":0}}}`, string(b))
+	require.NotNil(got.Range["profit"].GTE)
+	require.Equal(int64(0), *got.Range["profit"].GTE)
+}
+
+// TestZeroBoost_Emitted guards the same behavior for Boost, which is now *float64.
+func (r *RangeTestSuite) TestZeroBoost_Emitted() {
+	require := r.Require()
+	p := NewParam[string]().SetGTE("a").SetBoost(0)
+	b, err := json.Marshal(p)
+
+	require.NoError(err)
+	require.JSONEq(`{"gte":"a","boost":0}`, string(b))
+}
+
+func (r *RangeTestSuite) TestValidate() {
+	require := r.Require()
+	tests := []struct {
+		name    string
+		param   *Param[int64]
+		wantErr bool
+	}{
+		{
+			name:  "valid single lower bound",
+			param: NewParam[int64]().SetGTE(1),
+		},
+		{
+			name:  "valid lower and upper bound",
+			param: NewParam[int64]().SetGTE(1).SetLTE(10),
+		},
+		{
+			name:    "GT and GTE both set",
+			param:   NewParam[int64]().SetGT(1).SetGTE(2),
+			wantErr: true,
+		},
+		{
+			name:    "LT and LTE both set",
+			param:   NewParam[int64]().SetLT(1).SetLTE(2),
+			wantErr: true,
+		},
+		{
+			name:    "no bounds set",
+			param:   NewParam[int64](),
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		r.Run(tt.name, func() {
+			err := tt.param.Validate()
+			if tt.wantErr {
+				require.Error(err)
+				return
+			}
+			require.NoError(err)
+		})
+	}
 }
 
 func TestRange(t *testing.T) {


### PR DESCRIPTION
The ranging package's Param.GT/GTE/LT/LTE were typed as string, which meant every range bound had to be stringified regardless of the target field's actual Elasticsearch type (long, float, date, keyword, etc.). That worked because JSON doesn't distinguish quoted numbers strictly, but it discarded compile-time safety and made it easy to build a range query against the wrong type without noticing.

This change makes Param and Range generic over a Value constraint covering integers, floats, strings, and time.Time, so a call site like NewParam[int64]().SetGTE(100000) is now correctly typed end to end, and mixing incompatible bound types on the same param is a compile error rather than a runtime surprise.

Along the way, GT, GTE, LT, LTE, and Boost moved from bare values to pointers. This fixes a latent bug: with omitempty on a bare float64/numeric field, an explicitly-set zero value (a 0 boost, a 0 lower bound) was indistinguishable from "unset" and got silently dropped from the request. Pointers make zero a valid, transmittable value.

A new Param.Validate() method catches two mistakes Elasticsearch would otherwise reject: setting both GT and GTE (or both LT and LTE) on the same field, and constructing a param with no bounds at all.

Tests were updated to match (string-bound suite preserved, plus new coverage for numeric, float, and time.Time bounds, the zero-value regression, and Validate()).

This is a breaking API change — any code calling NewParam() / New() without a type argument, or relying on GT/GTE/LT/LTE/Boost being non-pointer, will need to be updated.